### PR TITLE
feat: Update for populate exchange

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 
 # production
 /build
+/src/build
 
 # misc
 .DS_Store

--- a/introspect-schema
+++ b/introspect-schema
@@ -1,0 +1,36 @@
+#! /usr/bin/env node
+
+const { introspectionQuery } = require('graphql');
+const fetch = require('node-fetch');
+const fs = require('fs');
+const path = require('path');
+
+let graphqlEndpoint;
+if (process.env.NODE_ENV === 'production') {
+  graphqlEndpoint = 'https://threed-test-api.herokuapp.com/graphql';
+} else {
+  graphqlEndpoint = 'http://localhost:3000/graphql';
+}
+
+(async () => {
+  const res = await fetch(graphqlEndpoint, {
+    method: 'POST',
+    body: JSON.stringify({
+      query: introspectionQuery
+    }),
+    headers: {
+      'Content-Type': 'application/json'
+    }
+  });
+
+  const { data } = await res.json();
+
+  if (!fs.existsSync(path.resolve(__dirname, './src/build'))) {
+    fs.mkdirSync(path.resolve(__dirname, './src/build'));
+  }
+
+  fs.writeFileSync(
+    path.resolve(__dirname, './src/build/schema.json'),
+    JSON.stringify(data, null, 2)
+  );
+})();

--- a/package.json
+++ b/package.json
@@ -16,8 +16,9 @@
     "urql": "1.7.0"
   },
   "scripts": {
-    "start": "react-scripts start",
-    "build": "react-scripts build",
+    "introspect": "./introspect-schema",
+    "start": "yarn introspect && react-scripts start",
+    "build": "yarn introspect && react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject"
   },

--- a/src/modules/threads/common/useNewLikes.js
+++ b/src/modules/threads/common/useNewLikes.js
@@ -1,8 +1,8 @@
 import { useSubscription } from 'urql';
 
-export const useNewLikes = (id) => {
+export const useNewLikes = id => {
   return useSubscription({ query: NEW_LIKES_SUBSCRIPTION, variables: { id } });
-}
+};
 
 const NEW_LIKES_SUBSCRIPTION = `
   subscription($id: ID!) {

--- a/src/modules/threads/common/useNewReplies.js
+++ b/src/modules/threads/common/useNewReplies.js
@@ -1,4 +1,4 @@
-import { useSubscription } from "urql";
+import { useSubscription } from 'urql';
 
 export const useNewReplies = id => {
   return useSubscription({

--- a/src/modules/threads/create/index.js
+++ b/src/modules/threads/create/index.js
@@ -1,26 +1,29 @@
-import React from "react";
-import gql from "graphql-tag";
-import styled from "styled-components";
-import { useMutation } from "urql";
-import { THREAD_FRAGMENT } from "../fragments";
-import { Button } from "../../../common/Button";
-import { TextField } from "../../../common/TextField";
-import { useScrollToTop } from "../../../common/useScrollToTop";
+import React from 'react';
+import gql from 'graphql-tag';
+import styled from 'styled-components';
+import { useMutation } from 'urql';
+import { THREAD_FRAGMENT } from '../fragments';
+import { Button } from '../../../common/Button';
+import { TextField } from '../../../common/TextField';
+import { useScrollToTop } from '../../../common/useScrollToTop';
 
 const CreateThread = () => {
   useScrollToTop();
-  const [title, setTitle] = React.useState("");
+  const [title, setTitle] = React.useState('');
   const [text, setText] = React.useState('');
 
   const [result, createThread] = useMutation(CREATE_THREAD_MUTATION);
 
-  const onSubmit = React.useCallback(e => {
-    e.preventDefault();
-    createThread({ title, text }).then(() => {
-      setText('');
-      setTitle('');
-    });
-  }, [title, text, createThread]);
+  const onSubmit = React.useCallback(
+    e => {
+      e.preventDefault();
+      createThread({ title, text }).then(() => {
+        setText('');
+        setTitle('');
+      });
+    },
+    [title, text, createThread]
+  );
 
   return (
     <Wrapper>
@@ -71,10 +74,9 @@ const StyledButton = styled(Button)`
 const CREATE_THREAD_MUTATION = gql`
   mutation($title: String!, $text: String!) {
     createThread(input: { title: $title, text: $text }) {
-      ...ThreadFragment
+      node @populate
     }
   }
-  ${THREAD_FRAGMENT}
 `;
 
 export default CreateThread;

--- a/src/modules/threads/detail/reply/Create.js
+++ b/src/modules/threads/detail/reply/Create.js
@@ -10,12 +10,15 @@ const CreateReply = ({ threadId }) => {
 
   const [text, setText] = React.useState('');
 
-  const onSubmit = React.useCallback(e => {
-    e.preventDefault();
-    reply({ threadId, text }).then(() => {
-      setText('');
-    });
-  }, [text, reply, threadId]);
+  const onSubmit = React.useCallback(
+    e => {
+      e.preventDefault();
+      reply({ threadId, text }).then(() => {
+        setText('');
+      });
+    },
+    [text, reply, threadId]
+  );
 
   return (
     <Form onSubmit={onSubmit}>
@@ -31,7 +34,7 @@ const CreateReply = ({ threadId }) => {
       <StyledButton type="submit">Submit</StyledButton>
     </Form>
   );
-}
+};
 
 const Form = styled.form`
   display: flex;
@@ -47,8 +50,10 @@ const StyledButton = styled(Button)`
 const CREATE_REPLY_MUTATION = gql`
   mutation($threadId: ID!, $text: String!) {
     reply(input: { threadId: $threadId, text: $text }) {
-      id
-      likesNumber
+      node @populate
+      viewer {
+        thread(id: $threadId) @populate
+      }
     }
   }
 `;

--- a/src/modules/threads/detail/reply/index.js
+++ b/src/modules/threads/detail/reply/index.js
@@ -1,11 +1,11 @@
-import React from "react";
+import React from 'react';
 import styled from 'styled-components';
 import { useSubscription, useMutation } from 'urql';
 import gql from 'graphql-tag';
-import { timeDifferenceForDate } from "../../../../utils/timeDiff";
-import { LikeButton } from "../../common/LikeButton";
-import { REPLY_FRAGMENT } from "../../fragments";
-import { getToken } from "../../../../utils/auth";
+import { timeDifferenceForDate } from '../../../../utils/timeDiff';
+import { LikeButton } from '../../common/LikeButton';
+import { REPLY_FRAGMENT } from '../../fragments';
+import { getToken } from '../../../../utils/auth';
 
 const Reply = ({ text, id, createdBy, createdAt, likesNumber }) => {
   useSubscription({ query: NEW_REPLY_LIKE, variables: { id } });
@@ -18,16 +18,13 @@ const Reply = ({ text, id, createdBy, createdAt, likesNumber }) => {
         <Text>{text}</Text>
       </Body>
       <Footer>
-        <LikeButton
-          disabled={result.fetching || !getToken()}
-          onClick={() => like({ id })}
-        />
+        <LikeButton disabled={result.fetching || !getToken()} onClick={() => like({ id })} />
         {likesNumber} -&nbsp; created by {createdBy.username} -&nbsp;
         {timeDifferenceForDate(createdAt)}
       </Footer>
     </Wrapper>
   );
-}
+};
 
 const Wrapper = styled.div`
   border-bottom: 1px solid black;
@@ -53,16 +50,18 @@ const Text = styled.p`
 `;
 
 const LIKE_REPLY = gql`
-  mutation ($id: ID!) {
-    likeReply (replyId: $id) {
-      ...ReplyFragment
+  mutation($id: ID!) {
+    likeReply(replyId: $id) {
+      node @populate {
+        ...ReplyFragment
+      }
     }
   }
   ${REPLY_FRAGMENT}
 `;
 
 const NEW_REPLY_LIKE = gql`
-  subscription ($id: ID!) {
+  subscription($id: ID!) {
     newReplyLike(replyId: $id) {
       id
       createdBy {

--- a/src/modules/threads/list/Thread.js
+++ b/src/modules/threads/list/Thread.js
@@ -1,13 +1,13 @@
 import React from 'react';
 import styled from 'styled-components';
 import { useMutation } from 'urql';
-import { Link } from "@reach/router";
+import { Link } from '@reach/router';
 import { timeDifferenceForDate } from '../../../utils/timeDiff';
 import { useNewLikes, useNewReplies } from '../common';
 import { LikeButton } from '../common/LikeButton';
 import { getToken } from '../../../utils/auth';
 
-const Thead = ({ title, text, createdBy, likesNumber, repliesNumber, id, createdAt }) => {
+const Thread = ({ title, text, createdBy, likesNumber, repliesNumber, id, createdAt }) => {
   const [result, like] = useMutation(LIKE_THREAD_MUTATION);
 
   useNewLikes(id);
@@ -27,7 +27,7 @@ const Thead = ({ title, text, createdBy, likesNumber, repliesNumber, id, created
       </TextGroup>
     </Wrapper>
   );
-}
+};
 
 const Wrapper = styled.div`
   border-bottom: 1px solid black;
@@ -71,11 +71,9 @@ const TextGroup = styled.div`
 const LIKE_THREAD_MUTATION = `
   mutation($id: ID!) {
     likeThread(threadId: $id) {
-      id
-      hasUserLiked
-      likesNumber
+      node @populate
     }
   }
 `;
 
-export default Thead;
+export default Thread;

--- a/src/modules/threads/list/index.js
+++ b/src/modules/threads/list/index.js
@@ -1,15 +1,15 @@
-import React from "react";
-import { useQuery, useSubscription } from "urql";
-import Thread from "./Thread";
-import gql from "graphql-tag";
-import { THREAD_FRAGMENT } from "../fragments";
-import { useScrollToTop } from "../../../common/useScrollToTop";
+import React from 'react';
+import { useQuery, useSubscription } from 'urql';
+import Thread from './Thread';
+import gql from 'graphql-tag';
+import { THREAD_FRAGMENT } from '../fragments';
+import { useScrollToTop } from '../../../common/useScrollToTop';
 
 const Home = () => {
   useScrollToTop();
   const [{ fetching, data }] = useQuery({
     query: THREADS_QUERY,
-    variables: { sortBy: "LATEST" }
+    variables: { sortBy: 'LATEST' }
   });
 
   useSubscription({ query: NEW_THREAD_SUBSCRIPTION });


### PR DESCRIPTION
Adds the populate exchange and updates mutations to use it

## Prerequisites
- Requires deployment of https://github.com/kitten/threed-example-api/pull/2
- Requires urql exchange release of:
  - https://github.com/FormidableLabs/urql-exchange-graphcache/pull/151
  - https://github.com/FormidableLabs/urql-exchange-graphcache/pull/150